### PR TITLE
Convenience functions for PciAddress

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,12 @@ impl PciAddress {
     }
 }
 
+impl From<u32> for PciAddress {
+    fn from(f: u32) -> Self {
+        PciAddress(f)
+    }
+}
+
 impl fmt::Display for PciAddress {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(


### PR DESCRIPTION
Enabling these simplified the enumeration code for me. Please consider if they're helpful more generally, otherwise feel free to disregard.