### PR TITLE
64-bit BAR clarification

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,8 +290,8 @@ impl EndpointHeader {
                     let size = unsafe {
                         access.write(self.0, offset, 0xfffffff0);
                         access.write(self.0, offset + 4, 0xffffffff);
-                        let mut readback_low = access.read(self.0, offset);
-                        let mut readback_high = access.read(self.0, offset + 4);
+                        let readback_low = access.read(self.0, offset);
+                        let readback_high = access.read(self.0, offset + 4);
                         access.write(self.0, offset, address);
                         access.write(self.0, offset + 4, address_upper);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,7 +259,7 @@ impl EndpointHeader {
                 0b00 => {
                     let size = unsafe {
                         access.write(self.0, offset, 0xfffffff0);
-                        let mut readback = access.read(self.0, offset).get_bits(4..32);
+                        let mut readback = access.read(self.0, offset);
                         access.write(self.0, offset, address);
 
                         /*


### PR DESCRIPTION
According to http://www.lowlevel.eu/wiki/Peripheral_Component_Interconnect#Base-Address-Register, a 64-bit wide BAR is indeed a combination of two BARs where the second BAR only contains the remaining bits of the address, but to determine its size, the bits of the second BAR needs to be written as well.

Added a condition at the start of the function to avoid getting a BAR where there isn't one