### PR TITLE
feat: don't truncate reserved bits in `CommandRegister`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,7 @@ impl PciHeader {
 
     pub fn command(&self, access: &impl ConfigRegionAccess) -> CommandRegister {
         let data = unsafe { access.read(self.0, 0x4).get_bits(0..16) };
-        CommandRegister::from_bits_truncate(data as u16)
+        CommandRegister::from_bits_retain(data as u16)
     }
 
     pub fn update_command<F>(&self, access: &impl ConfigRegionAccess, f: F)
@@ -170,7 +170,7 @@ impl PciHeader {
         F: Fn(CommandRegister) -> CommandRegister,
     {
         let mut data = unsafe { access.read(self.0, 0x4) };
-        let new_command = f(CommandRegister::from_bits_truncate(data.get_bits(0..16) as u16));
+        let new_command = f(CommandRegister::from_bits_retain(data.get_bits(0..16) as u16));
         data.set_bits(0..16, new_command.bits() as u32);
         unsafe {
             access.write(self.0, 0x4, data);

--- a/src/register.rs
+++ b/src/register.rs
@@ -139,5 +139,6 @@ bitflags::bitflags! {
         const SERR_ENABLE = 1 << 8;
         const FAST_BACK_TO_BACK_ENABLE = 1 << 9;
         const INTERRUPT_DISABLE = 1 << 10;
+        const _ = !0;
     }
 }


### PR DESCRIPTION
Since these are reserved, but also part of the command field, we can include them like this.

See [bitflags — Externally defined flags](https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags).