### PR TITLE
feat: don't take explicit references to `ConfigRegionAccess`

### DIFF
--- a/src/capability/mod.rs
+++ b/src/capability/mod.rs
@@ -89,19 +89,19 @@ impl PciCapability {
     }
 }
 
-pub struct CapabilityIterator<'a, T: ConfigRegionAccess> {
+pub struct CapabilityIterator<T: ConfigRegionAccess> {
     address: PciAddress,
     offset: u16,
-    access: &'a T,
+    access: T,
 }
 
-impl<'a, T: ConfigRegionAccess> CapabilityIterator<'a, T> {
-    pub(crate) fn new(address: PciAddress, offset: u16, access: &'a T) -> CapabilityIterator<'a, T> {
+impl<T: ConfigRegionAccess> CapabilityIterator<T> {
+    pub(crate) fn new(address: PciAddress, offset: u16, access: T) -> CapabilityIterator<T> {
         CapabilityIterator { address, offset, access }
     }
 }
 
-impl<'a, T: ConfigRegionAccess> Iterator for CapabilityIterator<'a, T> {
+impl<T: ConfigRegionAccess> Iterator for CapabilityIterator<T> {
     type Item = PciCapability;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -117,7 +117,7 @@ impl<'a, T: ConfigRegionAccess> Iterator for CapabilityIterator<'a, T> {
                 id as u8,
                 PciCapabilityAddress { address: self.address, offset: self.offset },
                 extension,
-                self.access,
+                &self.access,
             );
             self.offset = next_ptr as u16;
             if let Some(cap) = cap {

--- a/src/capability/mod.rs
+++ b/src/capability/mod.rs
@@ -64,7 +64,7 @@ impl PciCapability {
         id: u8,
         address: PciCapabilityAddress,
         extension: u16,
-        access: &impl ConfigRegionAccess,
+        access: impl ConfigRegionAccess,
     ) -> Option<PciCapability> {
         match id {
             0x00 => None, // null capability

--- a/src/capability/msix.rs
+++ b/src/capability/msix.rs
@@ -16,7 +16,7 @@ impl MsixCapability {
     pub(crate) fn new(
         address: PciCapabilityAddress,
         control: u16,
-        access: &impl ConfigRegionAccess,
+        access: impl ConfigRegionAccess,
     ) -> MsixCapability {
         let table_size = control.get_bits(0..11) + 1;
         let table = unsafe { access.read(address.address, address.offset + 0x04) };
@@ -31,7 +31,7 @@ impl MsixCapability {
     /// `[MsixCapability::table_bar]` and `[MsixCapability::table_offset]`. The caller is therefore
     /// responsible for configuring this separately, as this crate does not have access to
     /// arbitrary physical memory.
-    pub fn set_enabled(&mut self, enabled: bool, access: &impl ConfigRegionAccess) {
+    pub fn set_enabled(&mut self, enabled: bool, access: impl ConfigRegionAccess) {
         let mut control = unsafe { access.read(self.address.address, self.address.offset) };
         control.set_bit(31, enabled);
         unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,8 +291,8 @@ impl EndpointHeader {
         }
     }
 
-    pub fn capabilities<'a, T: ConfigRegionAccess>(&self, access: &'a T) -> CapabilityIterator<'a, T> {
-        let pointer = self.capability_pointer(access);
+    pub fn capabilities<T: ConfigRegionAccess>(&self, access: T) -> CapabilityIterator<T> {
+        let pointer = self.capability_pointer(&access);
         CapabilityIterator::new(self.0, pointer, access)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,23 @@ pub trait ConfigRegionAccess {
     unsafe fn write(&self, address: PciAddress, offset: u16, value: u32);
 }
 
+impl<T: ConfigRegionAccess + ?Sized> ConfigRegionAccess for &T {
+    #[inline]
+    fn function_exists(&self, address: PciAddress) -> bool {
+        (**self).function_exists(address)
+    }
+
+    #[inline]
+    unsafe fn read(&self, address: PciAddress, offset: u16) -> u32 {
+        (**self).read(address, offset)
+    }
+
+    #[inline]
+    unsafe fn write(&self, address: PciAddress, offset: u16, value: u32) {
+        (**self).write(address, offset, value)
+    }
+}
+
 #[non_exhaustive]
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum HeaderType {


### PR DESCRIPTION
Only the last commit is breaking, but it might be worth it.