### PR TITLE
fix: don't take explicit reference in `update_interrupt`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -435,7 +435,7 @@ impl EndpointHeader {
         (data.get_bits(8..16) as u8, data.get_bits(0..8) as u8)
     }
 
-    pub fn update_interrupt<F>(&mut self, access: &impl ConfigRegionAccess, f: F)
+    pub fn update_interrupt<F>(&mut self, access: impl ConfigRegionAccess, f: F)
     where
         F: FnOnce((InterruptPin, InterruptLine)) -> (InterruptPin, InterruptLine),
     {


### PR DESCRIPTION
This applies https://github.com/rust-osdev/pci_types/pull/22 to https://github.com/rust-osdev/pci_types/pull/21.

It would be great if you could release 0.9.1 containing this fix for consistency. :)