### PR TITLE
Add method to get the address of any capability

### DIFF
--- a/src/capability/mod.rs
+++ b/src/capability/mod.rs
@@ -87,6 +87,28 @@ impl PciCapability {
             _ => Some(PciCapability::Unknown { address, id }),
         }
     }
+
+    pub fn address(&self) -> PciCapabilityAddress {
+        match *self {
+            PciCapability::PowerManagement(address) => address,
+            PciCapability::AcceleratedGraphicsPort(address) => address,
+            PciCapability::VitalProductData(address) => address,
+            PciCapability::SlotIdentification(address) => address,
+            PciCapability::Msi(msi_cap) => msi_cap.address,
+            PciCapability::CompactPCIHotswap(address) => address,
+            PciCapability::PciX(address) => address,
+            PciCapability::HyperTransport(address) => address,
+            PciCapability::Vendor(address) => address,
+            PciCapability::DebugPort(address) => address,
+            PciCapability::CompactPCICentralResourceControl(address) => address,
+            PciCapability::PciHotPlugControl(address) => address,
+            PciCapability::BridgeSubsystemVendorId(address) => address,
+            PciCapability::AGP3(address) => address,
+            PciCapability::PciExpress(address) => address,
+            PciCapability::MsiX(msix_cap) => msix_cap.address,
+            PciCapability::Unknown { address, id: _ } => address,
+        }
+    }
 }
 
 pub struct CapabilityIterator<T: ConfigRegionAccess> {

--- a/src/capability/msi.rs
+++ b/src/capability/msi.rs
@@ -47,7 +47,7 @@ pub enum TriggerMode {
 
 #[derive(Debug, Clone, Copy)]
 pub struct MsiCapability {
-    address: PciCapabilityAddress,
+    pub(super) address: PciCapabilityAddress,
     per_vector_masking: bool,
     is_64bit: bool,
     multiple_message_capable: MultipleMessageSupport,

--- a/src/capability/msix.rs
+++ b/src/capability/msix.rs
@@ -4,7 +4,7 @@ use bit_field::BitField;
 
 #[derive(Clone, Copy, Debug)]
 pub struct MsixCapability {
-    address: PciCapabilityAddress,
+    pub(super) address: PciCapabilityAddress,
     table_size: u16,
     /// Table BAR in bits 0..3 and offset into that BAR in bits 3..31
     table: u32,


### PR DESCRIPTION
Previously it wasn't possible to get the address of MSI and MSI-X capabilities.

This is necessary for Redox OS to gradually move towards using this crate for parsing capabilities and in general allows users to parse capabilties that are unsupported by this crate themself without breaking when this crate adds support for parsing them itself.