### PR TITLE
Add method to enable/disable function masking for MSI-X

### DIFF
--- a/src/capability/msix.rs
+++ b/src/capability/msix.rs
@@ -39,6 +39,18 @@ impl MsixCapability {
         }
     }
 
+    /// Enable/disable masking of all interrupts for this PCI function.
+    ///
+    /// Individual interrupt sources can be masked using mask field of the corresponding entry in
+    /// the MSI-X table.
+    pub fn set_function_mask(&mut self, mask: bool, access: impl ConfigRegionAccess) {
+        let mut control = unsafe { access.read(self.address.address, self.address.offset) };
+        control.set_bit(30, mask);
+        unsafe {
+            access.write(self.address.address, self.address.offset, control);
+        }
+    }
+
     /// The index of the BAR that contains the MSI-X table.
     pub fn table_bar(&self) -> u8 {
         self.table.get_bits(0..3) as u8

--- a/src/capability/msix.rs
+++ b/src/capability/msix.rs
@@ -39,6 +39,11 @@ impl MsixCapability {
         }
     }
 
+    pub fn enabled(&self, access: impl ConfigRegionAccess) -> bool {
+        let control = unsafe { access.read(self.address.address, self.address.offset) };
+        control.get_bit(31)
+    }
+
     /// Enable/disable masking of all interrupts for this PCI function.
     ///
     /// Individual interrupt sources can be masked using mask field of the corresponding entry in
@@ -49,6 +54,11 @@ impl MsixCapability {
         unsafe {
             access.write(self.address.address, self.address.offset, control);
         }
+    }
+
+    pub fn function_mask(&self, access: impl ConfigRegionAccess) -> bool {
+        let control = unsafe { access.read(self.address.address, self.address.offset) };
+        control.get_bit(30)
     }
 
     /// The index of the BAR that contains the MSI-X table.


### PR DESCRIPTION
Function masking needs to be disabled before any interrupts can be received.