### PR TITLE
fix: write compliant bit pattern for BAR sizing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,7 +321,7 @@ impl EndpointHeader {
             match bar.get_bits(1..3) {
                 0b00 => {
                     let size = unsafe {
-                        access.write(self.0, offset, 0xfffffff0);
+                        access.write(self.0, offset, 0xffffffff);
                         let mut readback = access.read(self.0, offset);
                         access.write(self.0, offset, address);
 
@@ -349,7 +349,7 @@ impl EndpointHeader {
                     let address_upper = unsafe { access.read(self.0, offset + 4) };
 
                     let size = unsafe {
-                        access.write(self.0, offset, 0xfffffff0);
+                        access.write(self.0, offset, 0xffffffff);
                         access.write(self.0, offset + 4, 0xffffffff);
                         let mut readback_low = access.read(self.0, offset);
                         let readback_high = access.read(self.0, offset + 4);


### PR DESCRIPTION
According to the PCI spec (v6.0, p 930), "[t]o determine how much address space a Function requires, system software should write a value of all 1's to each BAR register and then read the value back." QEMU (and possibly others) mask the provided address based on the size of the address space [[2]](https://gitlab.com/qemu-project/qemu/-/blob/v10.1.2/hw/pci/pci.c#L1658), which is always larger than 128 bytes for memory BARs, so the value of the last nibble has no effect. However, cloud-hypervisor (with possibly others) is more strict in its interpretation of the specification and check for exactly the all-bits-set pattern [[3]](https://github.com/cloud-hypervisor/cloud-hypervisor/blob/9acf610a7b612aea92f3a7fd9f32767c04338280/pci/src/configuration.rs#L979). On the latter platforms, the current pattern can be erroneously interpreted as a BAR relocation instead of sizing.